### PR TITLE
Fix page Y offset issue (window.pageYScroll > window.pageYOffset)

### DIFF
--- a/src/PhotoSwipe.vue
+++ b/src/PhotoSwipe.vue
@@ -87,7 +87,7 @@
                     index: index,
                     getThumbBoundsFn (index) {
                         const thumbnail = document.querySelectorAll('.preview-img-item')[index]
-                        const pageYScroll = window.pageYScroll || document.documentElement.scrollTop
+                        const pageYScroll = window.pageYOffset || document.documentElement.scrollTop
                         const rect = thumbnail.getBoundingClientRect()
                         return {
                             x: rect.left,


### PR DESCRIPTION
Change window.pageYScroll to window.pageYOffset.
There is no pageYScroll attribute on window object.